### PR TITLE
disable airbnb no-restricted-syntax

### DIFF
--- a/packages/eslint-config-convidera/changelog.md
+++ b/packages/eslint-config-convidera/changelog.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.5.0
+
+- Disable `no-restricted-syntax` from airbnb-base, because we use esnext everywhere and vite does not generate runtime generators for `for..in` and `for..of`

--- a/packages/eslint-config-convidera/index.js
+++ b/packages/eslint-config-convidera/index.js
@@ -76,5 +76,11 @@ module.exports = {
     ],
     'arrow-body-style': 0,
     'prefer-destructuring': 0,
+
+    'no-restricted-syntax': [
+      'off',
+      'ForOfStatement',
+      'ForInStatement',
+    ],
   },
 };

--- a/packages/eslint-config-convidera/package.json
+++ b/packages/eslint-config-convidera/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@convidera-team/eslint-config-convidera",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Eslint config used in Convidera",
   "main": "index.js",
   "author": "Convidera",

--- a/packages/eslint-config-convidera/package.json
+++ b/packages/eslint-config-convidera/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@convidera-team/eslint-config-convidera",
-  "version": "1.5.0",
+  "version": "1.4.0",
   "description": "Eslint config used in Convidera",
   "main": "index.js",
   "author": "Convidera",


### PR DESCRIPTION
vite (which we use everywhere except of couple projects) already considers evergreen browsers and does not transpile them, so i suggest to turn it off

