### PR TITLE
chore(stylelint-config): add package metadata

### DIFF
--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -12,6 +12,15 @@
   },
   "author": "Convidera",
   "license": "ISC",
+  "homepage": "https://github.com/convidera/frontend-kit/tree/main/packages/stylelint-config#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/convidera/frontend-kit.git",
+    "directory": "packages/stylelint-config"
+  },
+  "bugs": {
+    "url": "https://github.com/convidera/frontend-kit/issues"
+  },
   "publishConfig": {
     "access": "public"
   }


### PR DESCRIPTION
## Summary
- add npm `homepage` metadata for the stylelint config package README
- add npm `repository` metadata with the package `directory`
- add npm `bugs.url` metadata pointing to the repository issue tracker
- leave runtime code, dependencies, generated files, and version fields unchanged

## Validation
- node package manifest assertion for `homepage`, `repository`, and `bugs.url`
- `npm pack --dry-run --ignore-scripts --json` from `packages/stylelint-config`
- `git diff --check`