### PR TITLE
fix: add missing metadata fields to package.json

### DIFF
--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@convidera-team/stylelint-config-convidera",
   "version": "3.0.0",
+  "bugs": {
+    "url": "https://github.com/convidera/frontend-kit/issues"
+  },
   "description": "Stylelint config used in Convidera",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
Adds missing `bugs` metadata to `packages/stylelint-config/package.json`.